### PR TITLE
Disable debug data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changed
 - Update angular to ~1.5.6.
+- Disable debug data. See https://docs.angularjs.org/guide/production.
 
 ## 2.2.1 - 2016-05-31
 

--- a/main.js
+++ b/main.js
@@ -117,9 +117,14 @@ localDeps.forEach(function(register) {
 
 /* @ngInject */
 module.config(function(
-  $httpProvider, $locationProvider, $provide, $routeProvider) {
+  $compileProvider, $httpProvider, $locationProvider, $provide,
+  $routeProvider) {
   $locationProvider.html5Mode(true);
   $locationProvider.hashPrefix('!');
+
+  // Disable debug data
+  // See: https://docs.angularjs.org/guide/production
+  $compileProvider.debugInfoEnabled(false);
 
   // add non-route
   $routeProvider.otherwise({none: true});


### PR DESCRIPTION
See https://docs.angularjs.org/guide/production.

This should be done in production mode. I'm not sure if we need some special method beyond what's in the docs to make it easy to enable debug data in development mode.
