### PR TITLE
Fix root container class logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-angular ChangeLog
 
+### Changed
+- Fix root container class logic.
+
 ## 2.5.1 - 2017-02-14
 
 ### Changed

--- a/app-component.html
+++ b/app-component.html
@@ -8,9 +8,8 @@
     Please <a href="http://www.updateyourbrowser.net/">update your browser.</a>
   </div>
 
-  <div class="{{(app.ngClass.rootContainer && '') || 'container'}}"
-    ng-class="app.ngClass.rootContainer"
-    ng-style="app.ngStyle.rootContainer">
+  <div ng-class="$root.app.ngClass.rootContainer || 'container'"
+    ng-style="$root.app.ngStyle.rootContainer">
     <div ng-view></div>
 
     <div ng-if="!$ctrl.route.changing && !$ctrl.route.on">


### PR DESCRIPTION
- Fix ngClass.rootContainer logic:
  - default: 'container'
  - ngClass.rootContainer = 'myclass': set a specific class string
  - ngClass.rootContainer = {}: no class set
  - ngClass.rootContainer = {...}: standard ng-class behavior