### PR TITLE
Support both bedrock-angular-footer 2 and 3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-angular ChangeLog
 
+### Changed
+- Support both bedrock-angular-footer 2 and 3.
+
 ## 2.5.2 - 2017-02-22
 
 ### Changed

--- a/app-component.html
+++ b/app-component.html
@@ -35,13 +35,11 @@
       </div>
     </div>
 
-    <hr ng-if="::!$ctrl.config.productionMode" />
+    <hr ng-if="::!$ctrl.config.productionMode">
     <br-demo-warning></br-demo-warning>
 
-    <div ng-if="$ctrl.config.footer.show">
-      <hr/>
-      <br-footer ng-if="$ctrl.config.footer.show"></br-footer>
-    </div>
+    <hr ng-if="!$ctrl.route.vars.footer._hideOuterHr">
+    <br-footer ng-if="$ctrl.config.footer.show"></br-footer>
   </div>
 </div>
 <div ng-if="!$ctrl.isMain">


### PR DESCRIPTION
- Add private var to hide outer hr. bedrock-angular-footer 3 sets this
  automatically and uses its own hr. Moved in 3 to allow route vars to
  control footer visibility.