### PR TITLE
Ignore canceled route changes.

### DIFF
--- a/main.js
+++ b/main.js
@@ -402,7 +402,9 @@ module.run(function(
   });
 
   $rootScope.$on('$routeChangeStart', function(event, next, current) {
-    $rootScope.route.changing = true;
+    if(!event.defaultPrevented) {
+      $rootScope.route.changing = true;
+    }
   });
 
   // set page vars when route changes
@@ -442,6 +444,9 @@ module.run(function(
   $rootScope.app.ngStyle = {};
 
   function locationChangeStart(event) {
+    if(event && event.defaultPrevented) {
+      return;
+    }
     /* Handle switching between single-page app routes and server-side
     rendered pages.
 


### PR DESCRIPTION
When `event.preventDefault()` has been called in a route change listener, we should not set our route changing flags because the route won't be changed.