### PR TITLE
Simplify app-component.

### DIFF
--- a/app-component.html
+++ b/app-component.html
@@ -1,34 +1,22 @@
-<div ng-if="$ctrl.isMain">
-  <br-navbar></br-navbar>
-  <br-alerts br-fixed="true"></br-alerts>
+<br-root ng-if="$ctrl.isMain">
+  <br-header>
+    <br-navbar></br-navbar>
+    <!-- <br-alerts br-fixed="true"></br-alerts>-->
+  </br-header>
 
   <br-route-loading ng-if="$ctrl.route.changing"></br-route-loading>
 
-  <div ng-show="!$ctrl.route.changing" class="br-content">
-    <div ng-if="$ctrl.config.userAgent.obsolete" class="alert alert-danger">
-      Your browser ({{$ctrl.config.userAgent.family}}
-      {{$ctrl.config.userAgent.major}}) is <strong>out of date</strong>.
-      Please <a href="http://www.updateyourbrowser.net/">update your browser.</a>
-    </div>
-
-    <div ng-class="$root.app.ngClass.rootContainer || 'container'"
-      ng-style="$root.app.ngStyle.rootContainer">
-      <div class="br-main-ng-view" ng-view></div>
-
-      <hr ng-if="::!$ctrl.config.productionMode">
-      <br-demo-warning></br-demo-warning>
-
-      <hr ng-if="!$ctrl.route.vars.footer._hideOuterHr">
-      <br-footer ng-if="$ctrl.config.footer.show"></br-footer>
-    </div>
-  </div>
-</div>
-<div ng-if="!$ctrl.isMain">
+  <br-route ng-hide="$ctrl.route.changing">
+    <ng-view></ng-view>
+  </br-route>
+  
+  <br-footer ng-hide="$ctrl.route.changing"></br-footer>
+</br-root>
+<br-root-error ng-if="!$ctrl.isMain">
   <h2>Page Not Found</h2>
-
   <div>
     <p>Sorry, but the page you requested was not found.</p>
     <p>If this problem persists, please contact
     <a href="mailto:support@{{supportDomain}}">Customer Support</a>.</p>
   </div>
-</div>
+</br-root-error>


### PR DESCRIPTION
- Supported browser support moved to server side in bedrock-views.
- Remove "container" type support and let the main view handle it as needed.
- Remove demo-warning.
- Remove outer footer hr support.
- Add element names to allow overriding.

Looking for comments, not necessarily ready to merge yet:
- Should `br-alerts` be in the `br-header`?
- Where/how will `demo-warning` be added back?
- If the view is now responsible for handling its own container, the footer will always be outside that container, and therefore needs its own container or similar logic.  Is this ok?
- Should the "page not found" text be in some overridable component?
- Are the named elements a sufficient way to use this?  Could there be conflicts if you have a "base" app that overrides components but then you have a sub-app that again wants to override a component?